### PR TITLE
Add Bike Racks (Bicycle Parking) to the cycling map

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,13 @@
       "name": "transitopia-web",
       "version": "0.0.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.84.2",
         "maplibre-gl": "^5.6.2",
         "pmtiles": "^4.3.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
-        "wouter": "^3.7.1"
+        "wouter": "^3.7.1",
+        "zod": "^4.0.16"
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.1.11",
@@ -730,6 +732,32 @@
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.83.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.83.1.tgz",
+      "integrity": "sha512-OG69LQgT7jSp+5pPuCfzltq/+7l2xoweggjme9vlbCPa/d7D7zaqv5vN/S82SzSYZ4EDLTxNO1PWrv49RAS64Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.84.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.84.2.tgz",
+      "integrity": "sha512-cZadySzROlD2+o8zIfbD978p0IphuQzRWiiH3I2ugnTmz4jbjc0+TdibpwqxlzynEen8OulgAg+rzdNF37s7XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.83.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -1730,6 +1758,15 @@
       },
       "engines": {
         "node": ">= 14.6"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.16.tgz",
+      "integrity": "sha512-Djo/cM339grjI7/HmN+ixYO2FzEMcWr/On50UlQ/RjrWK1I/hPpWhpC76heCptnRFpH0LMwrEbUY50HDc0V8wg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -11,11 +11,13 @@
     "types": "tsc --noEmit"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.84.2",
     "maplibre-gl": "^5.6.2",
     "pmtiles": "^4.3.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "wouter": "^3.7.1"
+    "wouter": "^3.7.1",
+    "zod": "^4.0.16"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.11",

--- a/src/CyclingMap/CyclingMap.tsx
+++ b/src/CyclingMap/CyclingMap.tsx
@@ -4,6 +4,7 @@ import { mapSource, layers, pathLayerIds, otherLayerIds } from "./cycling-map-la
 import { useMap, useMapLayerEvent } from "../Map/MapUtils.ts";
 import { type MapCyclingElement, type MapParkingElement } from "../Map/MapData.ts";
 import { MapOverlayWindow } from "../Map/MapOverlayWindow.tsx";
+import { InfoboxBikeParking } from "./InfoboxBikeParking.tsx";
 
 export const CyclingMap: React.FC = () => {
 
@@ -104,6 +105,8 @@ export const CyclingMap: React.FC = () => {
         }
     }, [map, selectedFeature]);
 
+    const closeInfobox = React.useCallback(() => setSelectedFeature(undefined), []);
+
     return <>
         {
             selectedFeature?.type === "cycling_way" ?
@@ -117,7 +120,7 @@ export const CyclingMap: React.FC = () => {
                             }
                         </div>
                         <div className="flex-none">
-                            <button className="hover:bg-gray-200 px-2 rounded-lg" onClick={() => setSelectedFeature(undefined)}>x</button>
+                            <button className="hover:bg-gray-200 px-2 rounded-lg" onClick={closeInfobox}>x</button>
                         </div>
                     </div>
                     {selectedFeature.construction ? <span className="inline-block m-1 px-1 rounded-md bg-red-600 text-white">Under Construction</span> : null}
@@ -132,21 +135,7 @@ export const CyclingMap: React.FC = () => {
                 </MapOverlayWindow>
             : selectedFeature?.type === "bicycle_parking" ?
                 <MapOverlayWindow className="top-24">
-                    <div className="flex">
-                        <div className="flex-1">
-                            {selectedFeature.name ?
-                                <><strong>{selectedFeature.name}</strong> (Bicycle Parking)</>
-                                :
-                                <strong>Bicycle Parking</strong>
-                            }
-                        </div>
-                        <div className="flex-none">
-                            <button className="hover:bg-gray-200 px-2 rounded-lg" onClick={() => setSelectedFeature(undefined)}>x</button>
-                        </div>
-                    </div>
-                    {selectedFeature.capacity ? <div>Capacity: {selectedFeature.capacity} bikes.</div> : null}
-                    <br />
-                    <a className="text-slate-500 text-sm" href={`https://www.openstreetmap.org/node/${selectedFeature.id}`}>View or edit this entry on OpenStreetMap</a>
+                    <InfoboxBikeParking featureType="node" osmId={parseInt(selectedFeature.id, 10)} closeInfobox={closeInfobox} />
                 </MapOverlayWindow>
             : null
         }

--- a/src/CyclingMap/CyclingMap.tsx
+++ b/src/CyclingMap/CyclingMap.tsx
@@ -135,7 +135,8 @@ export const CyclingMap: React.FC = () => {
                 </MapOverlayWindow>
             : selectedFeature?.type === "bicycle_parking" ?
                 <MapOverlayWindow className="top-24">
-                    <InfoboxBikeParking featureType="node" osmId={parseInt(selectedFeature.id, 10)} closeInfobox={closeInfobox} />
+                    {selectedFeature.osmNodeId && <InfoboxBikeParking featureType="node" osmId={parseInt(selectedFeature.osmNodeId, 10)} closeInfobox={closeInfobox} />}
+                    {selectedFeature.osmWayId && <InfoboxBikeParking featureType="way" osmId={parseInt(selectedFeature.osmWayId, 10)} closeInfobox={closeInfobox} />}
                 </MapOverlayWindow>
             : null
         }

--- a/src/CyclingMap/CyclingMap.tsx
+++ b/src/CyclingMap/CyclingMap.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { mapSource, layers } from "./cycling-map-layers.ts";
+import { mapSource, layers, pathLayerIds, otherLayerIds } from "./cycling-map-layers.ts";
 import { useMap, useMapLayerEvent } from "../Map/MapUtils.ts";
 import { type MapCyclingElement, type MapParkingElement } from "../Map/MapData.ts";
 import { MapOverlayWindow } from "../Map/MapOverlayWindow.tsx";
@@ -69,16 +69,8 @@ export const CyclingMap: React.FC = () => {
         }
     }, [map]);
 
-    useMapLayerEvent("mousemove", "cycling_path_1", handleMouseOver);
-    useMapLayerEvent("mousemove", "cycling_path_2", handleMouseOver);
-    useMapLayerEvent("mousemove", "cycling_path_3", handleMouseOver);
-    useMapLayerEvent("mousemove", "cycling_path_4", handleMouseOver);
-    useMapLayerEvent("mousemove", "cycling_path_construction", handleMouseOver);
-    useMapLayerEvent("mouseleave", "cycling_path_1", handleMouseOut);
-    useMapLayerEvent("mouseleave", "cycling_path_2", handleMouseOut);
-    useMapLayerEvent("mouseleave", "cycling_path_3", handleMouseOut);
-    useMapLayerEvent("mouseleave", "cycling_path_4", handleMouseOut);
-    useMapLayerEvent("mouseleave", "cycling_path_construction", handleMouseOut);
+    useMapLayerEvent("mousemove", handleMouseOver, ...pathLayerIds, ...otherLayerIds);
+    useMapLayerEvent("mouseleave", handleMouseOut, ...pathLayerIds, ...otherLayerIds);
 
     const handleClick = React.useCallback((e: maplibregl.MapLayerEventType["click"]) => {
         const feature = e.features?.[0];
@@ -96,12 +88,8 @@ export const CyclingMap: React.FC = () => {
         );
     }, [map]);
 
-    useMapLayerEvent("click", "cycling_path_1", handleClick);
-    useMapLayerEvent("click", "cycling_path_2", handleClick);
-    useMapLayerEvent("click", "cycling_path_3", handleClick);
-    useMapLayerEvent("click", "cycling_path_4", handleClick);
-    useMapLayerEvent("click", "cycling_path_construction", handleClick);
-    useMapLayerEvent("click", "bike_parking_point", handlePointClick);
+    useMapLayerEvent("click", handleClick, ...pathLayerIds);
+    useMapLayerEvent("click", handlePointClick, ...otherLayerIds);
 
     React.useEffect(() => {
         if (!map) return;

--- a/src/CyclingMap/InfoboxBikeParking.tsx
+++ b/src/CyclingMap/InfoboxBikeParking.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+
+import { useOsmNode } from "../OSMData/osm-data-loader.ts";
+import { bikeParkingSchema } from "../OSMData/osm-micromobility.ts";
+
+interface Props {
+    featureType: "node";
+    osmId: number | undefined;
+    closeInfobox: () => void;
+}
+
+export const InfoboxBikeParking: React.FC<Props> = (props) => {
+
+    const { data, error: osmError } = useOsmNode(props.osmId, bikeParkingSchema);
+    if (data) console.log('data', data);
+
+    if (osmError) {
+        console.log("OpenStreetMap loading error:", osmError);
+    }
+
+    return <>
+        <div className="flex">
+            <div className="flex-1">
+                {data?.name ?
+                    <><strong>{data.name}</strong> (Bicycle Parking)</>
+                    :
+                    <strong>Bicycle Parking</strong>
+                }
+            </div>
+            <div className="flex-none">
+                <button className="hover:bg-gray-200 px-2 rounded-lg" onClick={props.closeInfobox}>x</button>
+            </div>
+        </div>
+        {
+            data ? <>
+                {data.capacity ? <div>Capacity: {data.capacity} bikes.</div> : null}
+            </> :
+            osmError ? <p>Error: unable to load data from OpenStreetMap.</p> :
+            <>Loading...</>
+        }
+        <br />
+        <a className="text-slate-500 text-sm" href={`https://www.openstreetmap.org/${props.featureType}/${props.osmId}`}>View or edit this entry on OpenStreetMap</a>
+    </>
+}

--- a/src/CyclingMap/InfoboxBikeParking.tsx
+++ b/src/CyclingMap/InfoboxBikeParking.tsx
@@ -32,9 +32,12 @@ export const InfoboxBikeParking: React.FC<Props> = (props) => {
             </div>
         </div>
         {
-            data ? <>
-                {data.capacity ? <div>Capacity: {data.capacity} bikes.</div> : null}
-            </> :
+            data ? <table>
+                <tbody>
+                    <tr><td className="pr-3">Capacity:</td><td>{data.capacity ? `${data.capacity} bikes` : <span className="text-slate-300">Unknown</span>}</td></tr>
+                    <tr><td className="pr-3">Type:</td><td>{data.bicycleParkingType ? data.bicycleParkingType : <span className="text-slate-300">Unknown</span>}</td></tr>
+                </tbody>
+            </table> :
             osmError ? <p>Error: unable to load data from OpenStreetMap.</p> :
             <>Loading...</>
         }

--- a/src/CyclingMap/InfoboxBikeParking.tsx
+++ b/src/CyclingMap/InfoboxBikeParking.tsx
@@ -1,17 +1,18 @@
 import React from "react";
 
-import { useOsmNode } from "../OSMData/osm-data-loader.ts";
+import { useOsmFeature } from "../OSMData/osm-data-loader.ts";
 import { bikeParkingSchema } from "../OSMData/osm-micromobility.ts";
+import { OsmFeatureType } from "../OSMData/osm-types.ts";
 
 interface Props {
-    featureType: "node";
+    featureType: typeof OsmFeatureType.Node | typeof OsmFeatureType.Way;
     osmId: number | undefined;
     closeInfobox: () => void;
 }
 
 export const InfoboxBikeParking: React.FC<Props> = (props) => {
 
-    const { data, error: osmError } = useOsmNode(props.osmId, bikeParkingSchema);
+    const { data, error: osmError } = useOsmFeature(props.featureType, props.osmId, bikeParkingSchema);
     if (data) console.log('data', data);
 
     if (osmError) {

--- a/src/CyclingMap/cycling-map-layers.ts
+++ b/src/CyclingMap/cycling-map-layers.ts
@@ -3,7 +3,7 @@
 // Code license: MIT (see repository's LICENSE file) 
 // Design license: CC-BY 4.0 https://creativecommons.org/licenses/by/4.0/
 
-import type { LayerSpecification } from "maplibre-gl";
+import type { ExpressionSpecification, LayerSpecification } from "maplibre-gl";
 import { defaultLineLayout, interpolateZoom, mapSource as baseMapSource } from "../Map/basemap-layers.ts";
 
 // Which map "source" file (which .pmtiles file) the cycling data layers are found in
@@ -18,6 +18,17 @@ export const pathLayerIds = [
     "cycling_path_construction"
 ];
 export const otherLayerIds = ["bike_parking_point"];
+
+/**
+ * Helper: the resulting color should normally be 'color',
+ * but make it salmon colored when hovered or selected.
+ */
+export const colorWithHoverAndSelectionStates = (color: string) => [
+    "case",
+    ["boolean", ["feature-state", "selected"], false], "rgba(200, 100, 100, 1)",
+    ["boolean", ["feature-state", "hover"], false], "rgba(200, 100, 100, 1)",
+    color,
+] satisfies ExpressionSpecification;
 
 export const layers: LayerSpecification[] = [
     {
@@ -36,12 +47,7 @@ export const layers: LayerSpecification[] = [
             "visibility": "visible",
         },
         "paint": {
-            "line-color": [
-                "case",
-                ["boolean", ["feature-state", "selected"], false], "rgba(50, 50, 200, 1)",
-                ["boolean", ["feature-state", "hover"], false], "rgba(200, 100, 100, 1)",
-                "rgba(226, 109, 35, 1)",
-            ],
+            "line-color": colorWithHoverAndSelectionStates("rgba(226, 109, 35, 1)"),
             "line-width": interpolateZoom({ z10: 3, z16: 4 }),
             "line-dasharray": [0.4, 1],
         },
@@ -59,12 +65,7 @@ export const layers: LayerSpecification[] = [
         ],
         layout: defaultLineLayout,
         "paint": {
-            "line-color": [
-                "case",
-                ["boolean", ["feature-state", "selected"], false], "rgba(50, 50, 200, 1)",
-                ["boolean", ["feature-state", "hover"], false], "rgba(200, 100, 100, 1)",
-                "rgba(26, 109, 35, 1)",
-            ],
+            "line-color": colorWithHoverAndSelectionStates("rgba(26, 109, 35, 1)"),
             "line-width": interpolateZoom({ z10: 2, z16: 8 }),
         },
     },
@@ -81,12 +82,7 @@ export const layers: LayerSpecification[] = [
         ],
         layout: defaultLineLayout,
         "paint": {
-            "line-color": [
-                "case",
-                ["boolean", ["feature-state", "selected"], false], "rgba(50, 50, 200, 1)",
-                ["boolean", ["feature-state", "hover"], false], "rgba(200, 100, 100, 1)",
-                "rgba(26, 109, 35, 1)",
-            ],
+            "line-color": colorWithHoverAndSelectionStates("rgba(26, 109, 35, 1)"),
             "line-width": interpolateZoom({ z10: 2, z16: 7 }),
         },
     },
@@ -123,12 +119,7 @@ export const layers: LayerSpecification[] = [
         ],
         layout: defaultLineLayout,
         "paint": {
-            "line-color": [
-                "case",
-                ["boolean", ["feature-state", "selected"], false], "rgba(50, 50, 200, 1)",
-                ["boolean", ["feature-state", "hover"], false], "rgba(200, 100, 100, 1)",
-                "rgba(26, 109, 35, 1)",
-            ],
+            "line-color": colorWithHoverAndSelectionStates("rgba(26, 109, 35, 1)"),
             "line-width": interpolateZoom({ z10: 3, z16: 6 }),
             // dashed lines when zoomed in greater than 12
             "line-dasharray": {
@@ -151,12 +142,7 @@ export const layers: LayerSpecification[] = [
         ],
         layout: defaultLineLayout,
         "paint": {
-            "line-color": [
-                "case",
-                ["boolean", ["feature-state", "selected"], false], "rgba(50, 50, 200, 1)",
-                ["boolean", ["feature-state", "hover"], false], "rgba(200, 100, 100, 1)",
-                "rgba(26, 50, 35, 1)",
-            ],
+            "line-color": colorWithHoverAndSelectionStates("rgba(26, 50, 35, 1)"),
             "line-width": interpolateZoom({ z10: 2, z16: 4 }),
             "line-dasharray": [0.3, 2],
         },
@@ -212,12 +198,7 @@ export const layers: LayerSpecification[] = [
             "circle-radius": interpolateZoom({ z8: 1, z12: 1, z16: 3 }),
             "circle-color": "rgba(231, 231, 131, 0.72)",
             "circle-stroke-width": interpolateZoom({ z8: 0.5, z12: 0.5, z16: 2 }),
-            "circle-stroke-color": [
-                "case",
-                ["boolean", ["feature-state", "selected"], false], "rgba(50, 50, 200, 1)",
-                ["boolean", ["feature-state", "hover"], false], "rgba(200, 100, 100, 1)",
-                "rgba(26, 109, 35, 1)",
-            ],
+            "circle-stroke-color": colorWithHoverAndSelectionStates("rgba(26, 109, 35, 1)"),
             "circle-stroke-opacity": interpolateZoom({ z12: 0, z14: 0.5, z16: 0.8 }),
         },
     },

--- a/src/CyclingMap/cycling-map-layers.ts
+++ b/src/CyclingMap/cycling-map-layers.ts
@@ -9,6 +9,15 @@ import { defaultLineLayout, interpolateZoom, mapSource as baseMapSource } from "
 // Which map "source" file (which .pmtiles file) the cycling data layers are found in
 export const mapSource = "transitopia-cycling";
 
+/** Layers with cycling paths, as opposed to other things like bike rack locations */
+export const pathLayerIds = [
+    "cycling_path_1",
+    "cycling_path_2",
+    "cycling_path_3",
+    "cycling_path_4",
+    "cycling_path_construction"
+];
+export const otherLayerIds = ["bike_parking_point"];
 
 export const layers: LayerSpecification[] = [
     {
@@ -203,7 +212,13 @@ export const layers: LayerSpecification[] = [
             "circle-radius": interpolateZoom({ z8: 1, z12: 1, z16: 3 }),
             "circle-color": "rgba(231, 231, 131, 0.72)",
             "circle-stroke-width": interpolateZoom({ z8: 0.5, z12: 0.5, z16: 2 }),
-            "circle-stroke-color": interpolateZoom({ z12: "rgba(26, 109, 35, 0)", z14: "rgba(26, 109, 35, 0.5)", z16: "rgba(26, 109, 35, 0.8)" }),
+            "circle-stroke-color": [
+                "case",
+                ["boolean", ["feature-state", "selected"], false], "rgba(50, 50, 200, 1)",
+                ["boolean", ["feature-state", "hover"], false], "rgba(200, 100, 100, 1)",
+                "rgba(26, 109, 35, 1)",
+            ],
+            "circle-stroke-opacity": interpolateZoom({ z12: 0, z14: 0.5, z16: 0.8 }),
         },
     },
 ];

--- a/src/CyclingMap/cycling-map-layers.ts
+++ b/src/CyclingMap/cycling-map-layers.ts
@@ -184,4 +184,26 @@ export const layers: LayerSpecification[] = [
             "text-halo-width": 2,
         },
     },
+    // Bike parking (points)
+    {
+        id: "bike_parking_point",
+        type: "circle",
+        source: mapSource,
+        "source-layer": "transitopia_cycling",
+        "filter": [
+            "all",
+            ["==", "$type", "Point"],
+            ["==", "amenity", "bicycle_parking"],
+        ],
+        layout: {
+            visibility: "visible",
+            "circle-sort-key": 1,
+        },
+        "paint": {
+            "circle-radius": interpolateZoom({ z8: 1, z12: 1, z16: 3 }),
+            "circle-color": "rgba(231, 231, 131, 0.72)",
+            "circle-stroke-width": interpolateZoom({ z8: 0.5, z12: 0.5, z16: 2 }),
+            "circle-stroke-color": interpolateZoom({ z12: "rgba(26, 109, 35, 0)", z14: "rgba(26, 109, 35, 0.5)", z16: "rgba(26, 109, 35, 0.8)" }),
+        },
+    },
 ];

--- a/src/Map/MapData.ts
+++ b/src/Map/MapData.ts
@@ -21,14 +21,5 @@ export interface MapCyclingElement {
 export interface MapParkingElement {
     id: string;
     type: "bicycle_parking",
-    amenity: "bicycle_parking"; // TODO: or "kick-scooter_parking"
-    bicycle_parking?: "stands" | "wall_loops" | "rack" | "shed" | string; // TODO: validate this in planetiler to restrict to known values
     name?: string;
-    operator?: string;
-    indoor?: "yes" | "no";
-    access?: "private" | "customers" | "members";
-    capacity?: number;
-    covered?: "yes" | "no" | string;
-    cyclestreets_id?: string;
-    fee?: "yes" | "no"; // There are more details potentially available from "fee:conditional" but we don't support that yet.
 }

--- a/src/Map/MapData.ts
+++ b/src/Map/MapData.ts
@@ -22,4 +22,6 @@ export interface MapParkingElement {
     id: string;
     type: "bicycle_parking",
     name?: string;
+    osmNodeId?: string;
+    osmWayId?: string;
 }

--- a/src/Map/MapData.ts
+++ b/src/Map/MapData.ts
@@ -2,6 +2,8 @@
  * Data included for cycling tracks/lanes in the Transitopia Cycling layer of our map.
  */
 export interface MapCyclingElement {
+    id: string;
+    type: "cycling_way";
     name?: string;
     construction?: boolean;
     shared_with_pedestrians: boolean;
@@ -14,4 +16,19 @@ export interface MapCyclingElement {
     // Mostly for things under construction:
     website?: string;
     opening_date?: string;
+}
+
+export interface MapParkingElement {
+    id: string;
+    type: "bicycle_parking",
+    amenity: "bicycle_parking"; // TODO: or "kick-scooter_parking"
+    bicycle_parking?: "stands" | "wall_loops" | "rack" | "shed" | string; // TODO: validate this in planetiler to restrict to known values
+    name?: string;
+    operator?: string;
+    indoor?: "yes" | "no";
+    access?: "private" | "customers" | "members";
+    capacity?: number;
+    covered?: "yes" | "no" | string;
+    cyclestreets_id?: string;
+    fee?: "yes" | "no"; // There are more details potentially available from "fee:conditional" but we don't support that yet.
 }

--- a/src/Map/MapUtils.ts
+++ b/src/Map/MapUtils.ts
@@ -2,7 +2,7 @@ import React from "react";
 import type * as MapLibreGL from "maplibre-gl";
 export type MapLibreGLType = typeof MapLibreGL;
 
-export const MapContext: React.Context<{ map?: maplibregl.Map }> = React.createContext({});
+export const MapContext = React.createContext<{ map: maplibregl.Map | undefined }>({ map: undefined });
 
 export const MapLibreGLContext: React.Context<{ maplibregl?: MapLibreGLType }> = React.createContext({});
 

--- a/src/Map/MapUtils.ts
+++ b/src/Map/MapUtils.ts
@@ -11,17 +11,17 @@ export const useMap = () => React.useContext(MapContext)?.map;
 /**
  * Register an event handler for a map event, but limited to a specific layer of the map
  * @param eventName The event to handle
- * @param layerName Which map layer to watch for the event
  * @param handler The handler to call
+ * @param layerName Which map layers to watch for the event
  */
-export function useMapLayerEvent<eventName extends "click" | "mouseenter" | "mouseleave" | "mousemove">(eventName: eventName, layerName: string, handler: (event: maplibregl.MapLayerEventType[eventName]) => void) {
+export function useMapLayerEvent<eventName extends "click" | "mouseenter" | "mouseleave" | "mousemove">(eventName: eventName, handler: (event: maplibregl.MapLayerEventType[eventName]) => void, ...layerNames: string[]) {
     const map = useMap();
     React.useEffect(() => {
         if (!map) return;
-        map.on(eventName, layerName, handler);
+        layerNames.forEach(layerName => map.on(eventName, layerName, handler));
         // Cleanup when the handler changes or the component is destroyed:
-        return () => { map?.off(eventName, layerName, handler); };
-    }, [map, eventName, layerName, handler]);
+        return () => { layerNames.forEach(layerName => map?.off(eventName, layerName, handler)); };
+    }, [map, eventName, handler, ...layerNames]); // Note: without '...', layerNames would be shown as changing every time.
 }
 
 /**

--- a/src/OSMData/osm-data-loader.ts
+++ b/src/OSMData/osm-data-loader.ts
@@ -11,10 +11,9 @@ const overpassEndpoint = "https://overpass-api.de/api/interpreter";
 class OsmEntityNotFound extends Error {}
 
 /**
- * "Raw" data about an OSM node (a point), as returned from the Overpass API
- * or our `useOsmNode` function.
+ * "Raw" data about an OSM node (a point), as returned from the Overpass API.
  */
-export interface RawOsmNode {
+interface RawOsmNode {
     type: "node";
     id: number;
     lat: number;
@@ -23,35 +22,62 @@ export interface RawOsmNode {
 }
 
 /**
- * Hook to get data from an OpenStreetMap node
+ * "Raw" data about an OSM way (a line or area), as returned from the Overpass API.
+ */
+interface RawOsmWay {
+    type: "way";
+    id: number;
+    nodes: number[]; // Note: it's possible to ask the API to give these recursively so we get the coordinates and not just the IDs, but we haven't needed that yet.
+    tags: Record<string, string>;
+}
+
+/**
+ * "Raw" data about an OSM relation, as returned from the Overpass API.
+ */
+interface RawOsmRelation {
+    type: "relation";
+    id: number;
+    members: { type: "way" | "node" | "relation", ref: number, role: string };
+    tags: Record<string, string>;
+}
+
+type RawOsmFeature = RawOsmNode | RawOsmWay | RawOsmRelation;
+
+/**
+ * Hook to get data from an OpenStreetMap node/way/relation
  * e.g. https://www.openstreetmap.org/node/5324432722
+ * e.g. https://www.openstreetmap.org/way/697625710
+ * e.g. https://www.openstreetmap.org/relation/7882446
  * 
  * Warning: Nodes, Way, and Relations each have their own ID space,
  * so the same ID can exist as a (totally unrelated) node, way, and/or relation.
  */
-export function useOsmNode<Schema extends z.ZodType>(nodeId: number | undefined, schema: Schema): UseQueryResult<z.output<Schema>, Error> {
+export function useOsmFeature<Schema extends z.ZodType>(featureType: OsmFeatureType | undefined, id: number | undefined, schema: Schema): UseQueryResult<z.output<Schema>, Error> {
     return useQuery({
-        queryKey: ["osmNode", nodeId],
+        queryKey: ["osmFeature", featureType, id],
         queryFn: async () => {
-            const result = await fetch(overpassEndpoint, {
+            const response = await fetch(overpassEndpoint, {
                 method: "POST",
-                body: "data="+ encodeURIComponent(`[out:json][timeout:10]; node(${nodeId}); out;`),
+                body: "data="+ encodeURIComponent(`[out:json][timeout:10]; ${featureType}(${id}); out;`),
             });
-            const fullData = await result.json();
+            const fullData = await response.json();
             if (fullData.elements.length !== 1) {
                 throw new OsmEntityNotFound();
             }
-            const nodeData = fullData.elements[0] as RawOsmNode;
+            const nodeData = fullData.elements[0] as RawOsmFeature;
             const parsed = schema.parse({
                 ...nodeData.tags,
-                featureType: OsmFeatureType.Node,
-                osmId: nodeId,
+                featureType,
+                osmId: id,
+                ...(nodeData.type === "way" ? nodeData.nodes : undefined),
+                ...(nodeData.type === "relation" ? nodeData.members : undefined),
             }) as Record<string, unknown>;
-            // All schemas MUST also match 'osmFeatureSchema':
-            osmFeatureSchema.parse(parsed);
             // For any tags that didn't match the schema or weren't expected, put them in 'otherTags'
-            return {...parsed, otherTags: Object.fromEntries(Object.entries(nodeData.tags).filter(([k]) => !(k in parsed)))} as any;
+            const result = {...parsed, otherTags: Object.fromEntries(Object.entries(nodeData.tags).filter(([k]) => !(k in parsed)))} as any;
+            // All schemas MUST also match 'osmFeatureSchema':
+            osmFeatureSchema.parse(result);
+            return result;
         },
-        enabled: nodeId !== undefined,
+        enabled: featureType !== undefined && id !== undefined,
     });
 }

--- a/src/OSMData/osm-data-loader.ts
+++ b/src/OSMData/osm-data-loader.ts
@@ -1,0 +1,57 @@
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import * as z from "zod";
+import { osmFeatureSchema, OsmFeatureType } from "./osm-types";
+
+/**
+ * The API endpoint for the Overpass API server that we're using.
+ * Overpass is a read-only optimized API for querying OpenStreetMap data.
+ */
+const overpassEndpoint = "https://overpass-api.de/api/interpreter";
+
+class OsmEntityNotFound extends Error {}
+
+/**
+ * "Raw" data about an OSM node (a point), as returned from the Overpass API
+ * or our `useOsmNode` function.
+ */
+export interface RawOsmNode {
+    type: "node";
+    id: number;
+    lat: number;
+    lon: number;
+    tags: Record<string, string>;
+}
+
+/**
+ * Hook to get data from an OpenStreetMap node
+ * e.g. https://www.openstreetmap.org/node/5324432722
+ * 
+ * Warning: Nodes, Way, and Relations each have their own ID space,
+ * so the same ID can exist as a (totally unrelated) node, way, and/or relation.
+ */
+export function useOsmNode<Schema extends z.ZodType>(nodeId: number | undefined, schema: Schema): UseQueryResult<z.output<Schema>, Error> {
+    return useQuery({
+        queryKey: ["osmNode", nodeId],
+        queryFn: async () => {
+            const result = await fetch(overpassEndpoint, {
+                method: "POST",
+                body: "data="+ encodeURIComponent(`[out:json][timeout:10]; node(${nodeId}); out;`),
+            });
+            const fullData = await result.json();
+            if (fullData.elements.length !== 1) {
+                throw new OsmEntityNotFound();
+            }
+            const nodeData = fullData.elements[0] as RawOsmNode;
+            const parsed = schema.parse({
+                ...nodeData.tags,
+                featureType: OsmFeatureType.Node,
+                osmId: nodeId,
+            }) as Record<string, unknown>;
+            // All schemas MUST also match 'osmFeatureSchema':
+            osmFeatureSchema.parse(parsed);
+            // For any tags that didn't match the schema or weren't expected, put them in 'otherTags'
+            return {...parsed, otherTags: Object.fromEntries(Object.entries(nodeData.tags).filter(([k]) => !(k in parsed)))} as any;
+        },
+        enabled: nodeId !== undefined,
+    });
+}

--- a/src/OSMData/osm-micromobility.ts
+++ b/src/OSMData/osm-micromobility.ts
@@ -6,7 +6,15 @@ import { removeUndefinedKeys } from "./utils";
  * Bike racks or any other "parking space designed for bicycles, where one can leave a pedal cycle unattended in reasonable security"
  * https://wiki.openstreetmap.org/wiki/Tag:amenity%253Dbicycle_parking
  */
-export const bikeParkingSchema = z.object({
+export const bikeParkingSchema = z.preprocess((x, ctx) => {
+    // This messy preprocess code is just to rename 'bicycle_parking' to 'bicycleParkingType'
+    if (typeof x !== "object" || x === null) {
+        ctx.addIssue("not an object");
+        return x;
+    }
+    const {bicycle_parking: bicycleParkingType, ...rest} = x as Record<string, unknown>;
+    return {...rest, bicycleParkingType};
+}, z.object({
     ...osmFeatureSchema.shape,
     /** Transitopia-specific "type" key. */
     type: z.literal("bike_parking").default("bike_parking"),
@@ -72,6 +80,6 @@ export const bikeParkingSchema = z.object({
      */
     covered: z.transform(x => (x && x !== "no" ) ? true : (x == "no" ? false : undefined)).optional(),
    // Potentially add: access=*, capacity:cargo_bike=*, cargo_bike=*, fee=*
-}).transform(removeUndefinedKeys);
+}).transform(removeUndefinedKeys));
 
 export type BikeParkingFeature = z.infer<typeof bikeParkingSchema>;

--- a/src/OSMData/osm-micromobility.ts
+++ b/src/OSMData/osm-micromobility.ts
@@ -1,0 +1,77 @@
+import * as z from "zod";
+import { osmFeatureSchema, OsmFeatureType } from "./osm-types";
+import { removeUndefinedKeys } from "./utils";
+
+/**
+ * Bike racks or any other "parking space designed for bicycles, where one can leave a pedal cycle unattended in reasonable security"
+ * https://wiki.openstreetmap.org/wiki/Tag:amenity%253Dbicycle_parking
+ */
+export const bikeParkingSchema = z.object({
+    ...osmFeatureSchema.shape,
+    /** Transitopia-specific "type" key. */
+    type: z.literal("bike_parking").default("bike_parking"),
+    /** The upstream feature MUST have this tag `amenity=bicycle_parking` */
+    amenity: z.literal("bicycle_parking"),
+    /** Bike racks / bike parking locations can be a point (node) or a larger area (way). */
+    featureType: z.literal([OsmFeatureType.Node, OsmFeatureType.Way]),
+    /**
+     * What type of bike rack / bike parking this is.
+     * https://wiki.openstreetmap.org/wiki/Key:bicycle_parking
+     */
+    bicycleParkingType: z.literal([
+        "stands",
+        "wall_loops",
+        "rack",
+        "shed",
+        "bollard",
+        "wide_stands",
+        "building",
+        "lockers",
+        "wave",
+        "anchors",
+        "floor",
+        "safe_loops",
+        "ground_slots",
+        "handlebar_holder",
+        "informal",
+        "two-tier",
+        "streetpod",
+        "lean_and_stick",
+        "upright_stands",
+        "tree",
+        "saddle_holder",
+        "crossbar",
+        "rope",
+        "arcadia",
+        "log_with_slots",
+    ]).optional().catch(undefined),
+    name: z.string().optional(),
+    /**
+     * Company/organization that operates this bike parking facility, e.g. `Lime`
+     * https://wiki.openstreetmap.org/wiki/Key:operator
+     */
+    operator: z.string().optional(),
+    /**
+     * Identifies the exact operator, e.g. `Q39086685` for Lime
+     * https://wiki.openstreetmap.org/wiki/Key:operator:wikidata
+     */
+    "operator:wikidata": z.string().optional(),
+    /**
+     * Is this bike parking indoors?
+     * boolean, based on OSM values like `yes`, `no`, `room`, `area`, `wall`.
+     * https://wiki.openstreetmap.org/wiki/Key:indoor
+     */
+    indoor: z.transform(x => (x && x !== "no" ) ? true : (x == "no" ? false : undefined)).optional(),
+    /**
+     * "The total number of bikes that can be parked here. Please note that many stands are two-sided and can hold up to two bicycles for each stand."
+     */
+    capacity: z.coerce.number().optional().catch(undefined),
+    /**
+     * Is this covered?
+     * boolean, based on OSM values like `yes`, `no`, `partial` (becomes `yes`)
+     */
+    covered: z.transform(x => (x && x !== "no" ) ? true : (x == "no" ? false : undefined)).optional(),
+   // Potentially add: access=*, capacity:cargo_bike=*, cargo_bike=*, fee=*
+}).transform(removeUndefinedKeys);
+
+export type BikeParkingFeature = z.infer<typeof bikeParkingSchema>;

--- a/src/OSMData/osm-types.ts
+++ b/src/OSMData/osm-types.ts
@@ -1,0 +1,20 @@
+import * as z from "zod";
+
+export const OsmFeatureType = { Node: "node", Way: "way", Relation: "relation" } as const;
+export type OsmFeatureType = typeof OsmFeatureType[keyof typeof OsmFeatureType];
+
+/**
+ * Base schema for information about any OpenStreetMap feature
+ */
+export const osmFeatureSchema = z.object({
+    /** Transitopia-specific identifier for this feature type */
+    type: z.string().default("osmNode"),
+    /** Is this a node, a way, or a relation? */
+    featureType: z.literal([OsmFeatureType.Node, OsmFeatureType.Way, OsmFeatureType.Relation]),
+    /** The ID on OpenStreetMap. Only unique if used together with `featureType`! */
+    osmId: z.number(),
+    /** tags that weren't parsed by the particular schema we're using */
+    otherTags: z.record(z.string(), z.string()).optional(),
+    // TODO: add common tags like:
+    // https://wiki.openstreetmap.org/wiki/Photo_linking to all features
+});

--- a/src/OSMData/utils.ts
+++ b/src/OSMData/utils.ts
@@ -1,0 +1,7 @@
+/**
+ * Helper function to remove keys with undefined values from an object
+ * `{foo: undefined, bar: 15}` becomes `{bar: 15}`
+ */
+export function removeUndefinedKeys<Shape extends Record<string, unknown>>(obj: Shape): { [K in keyof Shape as (undefined extends Shape[K] ? (Shape[K] extends undefined ? never : K) : K)]: Exclude<Shape[K], undefined> } {
+    return Object.fromEntries(Object.entries(obj).filter(([_k, v]) => v !== undefined)) as any;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,21 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const queryClient = new QueryClient({
+    defaultOptions: {
+        queries: {
+            refetchOnMount: false,
+            refetchOnWindowFocus: false,
+        }
+    },
+});
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
-        <App />
+        <QueryClientProvider client={queryClient}>
+            <App />
+        </QueryClientProvider>
     </React.StrictMode>,
 )

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,9 @@
 
     /* Linting */
     "strict": true,
+    "exactOptionalPropertyTypes": true, // Distinguish between {key?: value} and {key: value | undefined} strictly.
+    "erasableSyntaxOnly": true, // Allow running code directly with Node.
+    "verbatimModuleSyntax": true, // Allow running code directly with Node.
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true


### PR DESCRIPTION
This PR, along with https://github.com/transitopia/planetiler-transitopia/pull/5 , lets us display bike racks on the map:

<img width="1080" height="515" alt="Screenshot 2025-08-08 at 1 26 47 PM" src="https://github.com/user-attachments/assets/5ca39a93-84f8-48ee-af18-a89dfd937534" />


TODOs:
- [x] Hover and selection states
- [x] Load the bike rack details from the Overpass API as needed; don't bake them into the tiles. Validate and type-convert the tags values as needed when loading them.
- [x] [Scooter parking?](https://wiki.openstreetmap.org/wiki/Tag:amenity%3Dkick-scooter_parking) - there seems to be none mapped in Vancouver area, so let's skip this.

Relates to https://github.com/transitopia/transitopia-web/issues/1